### PR TITLE
Fix API data parsing when requests fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ If the button above doesn't work, you can also perform the following steps manua
 
 ## Available Sensors
 
-After the integration is set up, the following sensors will be available for each configured vehicle:
+After the integration is set up, the following sensors will be available for each configured vehicle. Units of measurement are taken from your Drivvo account settings:
 
 - **Vehicle**: Vehicle name and model
-- **Odometer**: Current vehicle odometer reading
+- **Odometer**: Current vehicle odometer reading (units follow your Drivvo distance preference)
 - **Odometer Date**: Date of last odometer update
 - **Refuelling Total**: Number of total refuelling events
 - **Refuelling Last Average**: Last fuel consumption average
@@ -61,15 +61,15 @@ After the integration is set up, the following sensors will be available for eac
 - **Refuelling Type**: Type of fuel used
 - **Refuelling Reason**: Reason for the last refuelling
 - **Refuelling Date**: Date of last refuelling
-- **Refuelling Odometer**: Odometer of last refuelling
+- **Refuelling Odometer**: Odometer of last refuelling (uses your preferred distance unit)
 - **Refuelling Value**: Cost of last refuelling
 - **Refuelling Price**: Price per liter/gallon of last refuelling
 - **Refuelling Value Total**: Total cost of all refuellings
 - **Refuelling Tank Full**: Whether the tank was filled completely
-- **Refuelling Distance**: Distance traveled since last refuelling
+- **Refuelling Distance**: Distance traveled since last refuelling (uses your preferred distance unit)
 - **Refuelling Price Lowest**: Lowest fuel price recorded
-- **Refuelling Volume**: Volume of fuel in last refuelling
-- **Refuelling Volume Total**: Total volume of fuel refuelled
+- **Refuelling Volume**: Volume of fuel in last refuelling (uses your preferred volume unit)
+- **Refuelling Volume Total**: Total volume of fuel refuelled (uses your preferred volume unit)
 
 ## Debugging
 

--- a/custom_components/drivvo/__init__.py
+++ b/custom_components/drivvo/__init__.py
@@ -161,7 +161,7 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
                 response_refuelling.json(), key=sort_by_key, reverse=True
             )
         else:
-            api_data_refuellings = None
+            api_data_refuellings = []
         _LOGGER.debug(
             "API Response Data Vehicle %s - Refuelling: %s",
             id_vehicle,
@@ -175,7 +175,7 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
                 response_services.json(), key=sort_by_key, reverse=True
             )
         else:
-            api_data_services = None
+            api_data_services = []
         _LOGGER.debug(
             "API Response Data Vehicle %s - Services: %s", id_vehicle, api_data_services
         )
@@ -187,7 +187,7 @@ async def get_data_vehicle(hass, user, password, id_vehicle):
                 response_expenses.json(), key=sort_by_key, reverse=True
             )
         else:
-            api_data_expenses = None
+            api_data_expenses = []
         _LOGGER.debug(
             "API Response Data Vehicle %s - Expenses: %s", id_vehicle, api_data_expenses
         )

--- a/custom_components/drivvo/sensors.py
+++ b/custom_components/drivvo/sensors.py
@@ -50,7 +50,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         icon="mdi:speedometer",
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        unit_fn=lambda data: UnitOfLength.MILES
+        if data.distance_unit == "mi"
+        else UnitOfLength.KILOMETERS,
         value_fn=lambda data: data.odometer,
     ),
     DrivvoSensorEntityDescription(
@@ -67,7 +69,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         name="Refuelling Last Average",
         icon="mdi:fuel",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfFuelEfficiency.KILOMETERS_PER_LITER,
+        unit_fn=lambda data: UnitOfFuelEfficiency.MILES_PER_GALLON
+        if data.distance_unit == "mi"
+        else UnitOfFuelEfficiency.KILOMETERS_PER_LITER,
         value_fn=lambda data: data.refuelling_last_average,
         suggested_display_precision=2,
     ),
@@ -77,7 +81,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         name="Refuelling General Average",
         icon="mdi:fuel",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfFuelEfficiency.KILOMETERS_PER_LITER,
+        unit_fn=lambda data: UnitOfFuelEfficiency.MILES_PER_GALLON
+        if data.distance_unit == "mi"
+        else UnitOfFuelEfficiency.KILOMETERS_PER_LITER,
         value_fn=lambda data: data.refuelling_general_average,
         suggested_display_precision=2,
     ),
@@ -116,7 +122,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         name="Refuelling Odometer",
         icon="mdi:speedometer",
         device_class=SensorDeviceClass.DISTANCE,
-        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        unit_fn=lambda data: UnitOfLength.MILES
+        if data.distance_unit == "mi"
+        else UnitOfLength.KILOMETERS,
         value_fn=lambda data: data.refuelling_odometer,
     ),
     DrivvoSensorEntityDescription(
@@ -165,7 +173,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         icon="mdi:road",
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        unit_fn=lambda data: UnitOfLength.MILES
+        if data.distance_unit == "mi"
+        else UnitOfLength.KILOMETERS,
         value_fn=lambda data: data.refuelling_distance,
     ),
     DrivvoSensorEntityDescription(
@@ -185,7 +195,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         icon="mdi:fuel",
         device_class=SensorDeviceClass.VOLUME,
         state_class=SensorStateClass.TOTAL,
-        native_unit_of_measurement=UnitOfVolume.LITERS,
+        unit_fn=lambda data: UnitOfVolume.GALLONS
+        if data.distance_unit == "mi"
+        else UnitOfVolume.LITERS,
         value_fn=lambda data: data.refuelling_volume,
         suggested_display_precision=2,
     ),
@@ -196,7 +208,9 @@ SENSOR_TYPES: tuple[DrivvoSensorEntityDescription, ...] = (
         icon="mdi:fuel",
         device_class=SensorDeviceClass.VOLUME,
         state_class=SensorStateClass.TOTAL,
-        native_unit_of_measurement=UnitOfVolume.LITERS,
+        unit_fn=lambda data: UnitOfVolume.GALLONS
+        if data.distance_unit == "mi"
+        else UnitOfVolume.LITERS,
         value_fn=lambda data: data.refuelling_volume_total,
         suggested_display_precision=2,
     ),


### PR DESCRIPTION
## Summary
- avoid errors when requests to Drivvo API return unexpected results
- respect imperial vs metric distance settings from Drivvo
- honor volume unit preference from Drivvo

## Testing
- `ruff check custom_components/drivvo/sensors.py custom_components/drivvo/sensor.py custom_components/drivvo/__init__.py`
- `pytest -q` *(no tests collected)*
- `pre-commit run --files custom_components/drivvo/sensors.py README.md -q` *(fails: command not found)*
